### PR TITLE
Handle AST IndentationError due to dedent failures

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -1024,7 +1024,10 @@ def get_leading_words(line):
 
 def get_function_args(function_string):
     """Return the function arguments given the source-code string."""
-    function_arg_node = ast.parse(textwrap.dedent(function_string)).body[0].args
+    try:
+        function_arg_node = ast.parse(textwrap.dedent(function_string)).body[0].args
+    except IndentationError:
+        return []
     arg_nodes = function_arg_node.args
     kwonly_arg_nodes = function_arg_node.kwonlyargs
     return [arg_node.arg for arg_node in chain(arg_nodes, kwonly_arg_nodes)]


### PR DESCRIPTION
Sometimes, textwrap.dedent is unable to dedent the function string. In that case, trying to parse the AST from the string gives indentation error breaking the entire flake8 run.
This change will ignore the checks for that part, handling it gracefully.